### PR TITLE
Missing assignment in test.

### DIFF
--- a/tests/src/Unit/Plugin/Workflow/WorkflowTest.php
+++ b/tests/src/Unit/Plugin/Workflow/WorkflowTest.php
@@ -53,6 +53,7 @@ class WorkflowTest extends UnitTestCase {
     ];
     $workflow = new Workflow([], 'test', $plugin_definition, $guard_factory->reveal());
 
+    $states = $workflow->getStates();
     $state = $workflow->getState('draft');
     $this->assertEquals($state, $states['draft']);
     $this->assertEquals('draft', $state->getId());


### PR DESCRIPTION
Tests are failing because of unassigned variable.