### PR TITLE
Issue #2794537 - State machine should fire events when a transition is applied.

### DIFF
--- a/src/Event/WorkflowTransitionEvent.php
+++ b/src/Event/WorkflowTransitionEvent.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\state_machine\Event;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\state_machine\Plugin\Workflow\WorkflowState;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Defines the state change event.
+ */
+class WorkflowTransitionEvent extends Event {
+
+  /**
+   * The workflow state.
+   *
+   * @var \Drupal\state_machine\Plugin\Workflow\WorkflowState
+   */
+  protected $fromState;
+
+  /**
+   * The workflow state.
+   *
+   * @var \Drupal\state_machine\Plugin\Workflow\WorkflowState
+   */
+  protected $toState;
+
+  /**
+   * The entity.
+   *
+   * @var \Drupal\Core\Entity\ContentEntityInterface
+   */
+  protected $entity;
+
+  /**
+   * Constructs a new StateChangeEvent.
+   *
+   * @param \Drupal\state_machine\Plugin\Workflow\WorkflowState $from
+   *   The initial workflow state.
+   * @param \Drupal\state_machine\Plugin\Workflow\WorkflowState $to
+   *   The final workflow state.
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   */
+  public function __construct(WorkflowState $from, WorkflowState $to, ContentEntityInterface $entity) {
+    $this->fromState = $from;
+    $this->toState = $to;
+    $this->entity = $entity;
+  }
+
+  /**
+   * Gets the state transitioned from.
+   *
+   * @return \Drupal\state_machine\Plugin\Workflow\WorkflowState
+   *   The workflow state.
+   */
+  public function getFromState() {
+    return $this->fromState;
+  }
+
+  /**
+   * Gets the state transitioned to.
+   *
+   * @return \Drupal\state_machine\Plugin\Workflow\WorkflowState
+   *   The workflow state.
+   */
+  public function getToState() {
+    return $this->toState;
+  }
+
+  /**
+   * Gets the entity.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface
+   *   The entity.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+}

--- a/src/Plugin/Workflow/Workflow.php
+++ b/src/Plugin/Workflow/Workflow.php
@@ -158,6 +158,19 @@ class Workflow extends PluginBase implements WorkflowInterface, ContainerFactory
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function findTransition($from_state_id, $to_state_id) {
+    foreach ($this->getPossibleTransitions($from_state_id) as $transition) {
+      if ($transition->getToState()->getId() == $to_state_id) {
+        return $transition;
+      }
+    }
+    // No transition found.
+    return FALSE;
+  }
+
+  /**
    * Gets whether the given transition is allowed.
    *
    * @param \Drupal\state_machine\Plugin\Workflow\WorkflowTransition $transition

--- a/src/Plugin/Workflow/WorkflowInterface.php
+++ b/src/Plugin/Workflow/WorkflowInterface.php
@@ -98,4 +98,17 @@ interface WorkflowInterface {
    */
   public function getAllowedTransitions($state_id, EntityInterface $entity);
 
+  /**
+   * Takes two state ids and returns the transition for moving between them.
+   *
+   * @param string $from_state_id
+   *   The id of the initial state.
+   * @param string $to_state_id
+   *   The id of the final state.
+   *
+   * @return bool|\Drupal\state_machine\Plugin\Workflow\WorkflowTransition|mixed
+   *   Returns the WorkflowTransition if found, otherwise FALSE.
+   */
+  public function findTransition($from_state_id, $to_state_id);
+
 }

--- a/tests/modules/state_machine_test/src/EventSubscriber/WorkflowTransitionEventSubscriber.php
+++ b/tests/modules/state_machine_test/src/EventSubscriber/WorkflowTransitionEventSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\state_machine_test\EventSubscriber;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\state_machine\Event\WorkflowTransitionEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Test subscriber to state changes.
+ */
+class WorkflowTransitionEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [
+      'order.cancel.pre_transition' => 'cancelPresaveReaction',
+      'order.cancel.post_transition' => 'cancelPostsaveReaction',
+    ];
+    return $events;
+  }
+
+  /**
+   * Reacts to entity entering cancel state in the PreSave phase.
+   *
+   * @param \Drupal\state_machine\Event\WorkflowTransitionEvent $event
+   *   The state change event.
+   */
+  public function cancelPresaveReaction(WorkflowTransitionEvent $event) {
+    $state = $event->getToState();
+    $entity = $event->getEntity();
+    drupal_set_message(new TranslatableMarkup('@entity_label was @state_label at Pre-transition.', [
+      '@entity_label' => $entity->label(),
+      '@state_label' => $state->getLabel(),
+    ]));
+  }
+
+  /**
+   * Reacts to entity entering cancel state in the PreSave phase.
+   *
+   * @param \Drupal\state_machine\Event\WorkflowTransitionEvent $event
+   *   The state change event.
+   */
+  public function cancelPostsaveReaction(WorkflowTransitionEvent $event) {
+    $state = $event->getToState();
+    $entity = $event->getEntity();
+    drupal_set_message(new TranslatableMarkup('@entity_label was @state_label at Post-transition.', [
+      '@entity_label' => $entity->label(),
+      '@state_label' => $state->getLabel(),
+    ]));
+  }
+
+}

--- a/tests/modules/state_machine_test/state_machine_test.services.yml
+++ b/tests/modules/state_machine_test/state_machine_test.services.yml
@@ -3,3 +3,7 @@ services:
     class: Drupal\state_machine_test\Guard\FulfillmentGuard
     tags:
       - { name: state_machine.guard, group: order }
+  state_machine_test.event_subscriber:
+    class: Drupal\state_machine_test\EventSubscriber\WorkflowTransitionEventSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/tests/src/Kernel/StateItemTest.php
+++ b/tests/src/Kernel/StateItemTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\state_machine\StateItem;
+namespace Drupal\Tests\state_machine\Kernel;
 
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\field\Entity\FieldConfig;

--- a/tests/src/Kernel/WorkflowTransitionEventTest.php
+++ b/tests/src/Kernel/WorkflowTransitionEventTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\Tests\state_machine\Kernel;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the StateChangeEvent.
+ *
+ * @group state_machine
+ */
+class WorkflowTransitionEventTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'entity_test',
+    'state_machine',
+    'field',
+    'user',
+    'state_machine_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('user');
+
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => 'test_state',
+      'entity_type' => 'entity_test',
+      'type' => 'state',
+    ]);
+    $field_storage->save();
+
+    $field = FieldConfig::create([
+      'field_name' => 'test_state',
+      'entity_type' => 'entity_test',
+      'bundle' => 'entity_test',
+      'settings' => [
+        'workflow' => 'default',
+      ],
+    ]);
+    $field->save();
+  }
+
+  /**
+   * Tests the state change event dispatch and test subscriber.
+   */
+  public function testStateChangeEvent() {
+    $entity = EntityTest::create([
+      'name' => 'Tester',
+      'test_state' => ['value' => 'new'],
+    ]);
+    $entity->save();
+
+    /** @var \Drupal\state_machine\WorkflowManagerInterface $workflow_manager */
+    $workflow_manager = \Drupal::service('plugin.manager.workflow');
+    /** @var \Drupal\state_machine\Plugin\Workflow\Workflow $workflow */
+    $workflow = $workflow_manager->createInstance('default');
+    $transition = $workflow->getTransition('cancel');
+    $entity->test_state->first()->applyTransition($transition);
+    $entity->save();
+
+    $messages = drupal_get_messages();
+    $message = reset($messages);
+    $this->assertEquals('Tester was Canceled at Pre-transition.', (string) $message[0]);
+    $this->assertEquals('Tester was Canceled at Post-transition.', (string) $message[1]);
+  }
+
+}


### PR DESCRIPTION
Patch from comment #22 in https://www.drupal.org/node/2794537.